### PR TITLE
[EPO-7919] Event & News Callout EntryTypes

### DIFF
--- a/api/config/project/entryTypes/calloutEvent--e74470ea-c559-482e-9e3d-2241517a95a7.yaml
+++ b/api/config/project/entryTypes/calloutEvent--e74470ea-c559-482e-9e3d-2241517a95a7.yaml
@@ -1,0 +1,73 @@
+fieldLayouts:
+  b2fdd3dc-f966-4706-8206-e3d2b2e3a79e:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            autocapitalize: true
+            autocomplete: false
+            autocorrect: true
+            class: null
+            disabled: false
+            elementCondition: null
+            id: null
+            instructions: null
+            label: null
+            max: null
+            min: null
+            name: null
+            orientation: null
+            placeholder: null
+            readonly: false
+            requirable: false
+            size: null
+            step: null
+            tip: null
+            title: null
+            type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: 4ae3434b-d2d8-4042-8548-b10d52faf3a9
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: 7619020e-9b6f-4526-9359-d6cfb47b33a5 # Entry - Event
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 7302f4f1-cfe1-485d-ae03-d520103ade95
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: a860238f-3e0b-4387-835b-91bfaa21fdee
+        userCondition: null
+      -
+        elementCondition: null
+        elements:
+          -
+            elementCondition: null
+            fieldUid: 8b8ed305-e6e6-4754-925f-bb07427b2060 # Background Color
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 3e2af7d5-dcf3-45fe-8d18-14bbd636aaf1
+            userCondition: null
+            warning: null
+            width: 100
+        name: Appearance
+        uid: b1e422b5-4169-4f5f-99a3-fc942a8a7820
+        userCondition: null
+handle: calloutEvent
+hasTitleField: false
+name: 'Callout - Event'
+section: 7cad6f4e-cc7b-45cf-ac7b-6f383e77bc1b # Callouts
+sortOrder: 5
+titleFormat: '{eventEntry|first.title}'
+titleTranslationKeyFormat: null
+titleTranslationMethod: none

--- a/api/config/project/entryTypes/calloutNews--46db7366-f372-41c2-9f6a-dc30bcd7a946.yaml
+++ b/api/config/project/entryTypes/calloutNews--46db7366-f372-41c2-9f6a-dc30bcd7a946.yaml
@@ -1,0 +1,73 @@
+fieldLayouts:
+  6d3d2214-71ef-4452-9296-32eefae43c13:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            autocapitalize: true
+            autocomplete: false
+            autocorrect: true
+            class: null
+            disabled: false
+            elementCondition: null
+            id: null
+            instructions: null
+            label: null
+            max: null
+            min: null
+            name: null
+            orientation: null
+            placeholder: null
+            readonly: false
+            requirable: false
+            size: null
+            step: null
+            tip: null
+            title: null
+            type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: a8c3a152-49d0-4cf1-bce4-9970b43010bd
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: c5f150d4-fc85-4a5f-a3a7-4d4a1d655861 # Entry - News
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: de9b595d-b4af-4ac2-bd65-b6d1f8a32456
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: 736d29c8-2a6a-4396-82ed-81ac27b29e26
+        userCondition: null
+      -
+        elementCondition: null
+        elements:
+          -
+            elementCondition: null
+            fieldUid: 8b8ed305-e6e6-4754-925f-bb07427b2060 # Background Color
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 4c342a71-9aeb-4d67-8703-416d68d21c69
+            userCondition: null
+            warning: null
+            width: 100
+        name: Appearance
+        uid: c80853de-fb53-429a-925a-186a0d5fd8c1
+        userCondition: null
+handle: calloutNews
+hasTitleField: false
+name: 'Callout - News'
+section: 7cad6f4e-cc7b-45cf-ac7b-6f383e77bc1b # Callouts
+sortOrder: 4
+titleFormat: '{newsEntry|first.title}'
+titleTranslationKeyFormat: null
+titleTranslationMethod: none

--- a/api/config/project/fields/eventEntry--7619020e-9b6f-4526-9359-d6cfb47b33a5.yaml
+++ b/api/config/project/fields/eventEntry--7619020e-9b6f-4526-9359-d6cfb47b33a5.yaml
@@ -1,0 +1,35 @@
+columnSuffix: null
+contentColumnType: string
+fieldGroup: 9940892d-32f4-4399-acac-ab559ce1c82b # Common
+handle: eventEntry
+instructions: null
+name: 'Entry - Event'
+searchable: false
+settings:
+  allowSelfRelations: false
+  branchLimit: null
+  localizeRelations: false
+  maintainHierarchy: false
+  maxRelations: 1
+  minRelations: null
+  selectionCondition:
+    __assoc__:
+      -
+        - elementType
+        - craft\elements\Entry
+      -
+        - fieldContext
+        - global
+      -
+        - class
+        - craft\elements\conditions\entries\EntryCondition
+  selectionLabel: 'Select an Event Entry'
+  showSiteMenu: false
+  sources:
+    - 'section:4305f2e2-40b8-47b2-8b62-135b8b57be7f' # Events
+  targetSiteId: null
+  validateRelatedElements: false
+  viewMode: null
+translationKeyFormat: null
+translationMethod: site
+type: craft\fields\Entries

--- a/api/config/project/graphql/schemas/4fe339ec-7579-46f4-a362-df6ee8de4b3c.yaml
+++ b/api/config/project/graphql/schemas/4fe339ec-7579-46f4-a362-df6ee8de4b3c.yaml
@@ -1,10 +1,14 @@
 isPublic: true
 name: 'Public Schema'
 scope:
+  - 'sites.547128fa-4529-4483-9968-66425996b69f:read' # EN
+  - 'sites.2c2e1c6a-eb4d-44f1-9a43-8d79b326f354:read' # ES
   - 'sections.7cad6f4e-cc7b-45cf-ac7b-6f383e77bc1b:read' # Callouts
+  - 'entrytypes.fa15bb4c-adb8-4393-82c3-15c2b830867c:read' # Callout - quote
   - 'entrytypes.942c9e60-2760-42ed-b03b-9e5eb133751b:read' # Callout
   - 'entrytypes.34f61e7c-358c-48b8-8439-42bc05ed255c:read' # Callout - two-tone
-  - 'entrytypes.fa15bb4c-adb8-4393-82c3-15c2b830867c:read' # Callout - quote
+  - 'entrytypes.e74470ea-c559-482e-9e3d-2241517a95a7:read' # Callout - Event
+  - 'entrytypes.46db7366-f372-41c2-9f6a-dc30bcd7a946:read' # Callout - News
   - 'sections.4305f2e2-40b8-47b2-8b62-135b8b57be7f:read' # Events
   - 'entrytypes.6acd6e24-26c9-4e55-a35b-c29cd36a7a3c:read' # Events
   - 'sections.3a8b9653-cdd3-46ce-84b2-d73b5dc4de63:read' # Gallery
@@ -23,8 +27,8 @@ scope:
   - 'entrytypes.23eda090-7e8e-401d-ab49-ee4becc34935:read' # Pages
   - 'entrytypes.9d045432-a0fb-4fcd-8bca-3bc93b1f7056:read' # Educator Pages
   - 'entrytypes.26ca2777-e4c8-41b4-ac93-aa28d09117dd:read' # Student Pages
-  - 'entrytypes.15ca4b7f-3874-4461-aae9-869c9cdf076b:read' # Redirect Page
   - 'entrytypes.b55b0827-5ceb-45e1-bd3c-a35dc4638886:read' # Investigation Landing Page
+  - 'entrytypes.15ca4b7f-3874-4461-aae9-869c9cdf076b:read' # Redirect Page
   - 'sections.04a48967-eac4-449f-b164-c8ecbb7036d6:read' # Search Results
   - 'entrytypes.229f2975-93d3-4c6a-9996-dfa1de3004ef:read' # Search Results
   - 'sections.fb3283a6-7286-4b2b-a77a-010783dcee7e:read' # Slideshows
@@ -39,10 +43,10 @@ scope:
   - 'volumes.c3d1c243-1703-4117-abc7-88487a1f8f24:read' # Staff Profiles
   - 'volumes.d41cc960-99a4-41a8-a7a6-7891a22e4a93:read' # Asset Variants
   - 'volumes.51d86fa7-e37a-4926-97c8-3112fd6f2fbe:read' # Canto DAM
-  - 'globalsets.b8393df9-fb81-4d70-9ccb-6d030c818580:read' # Gallery Item Defaults
-  - 'globalsets.994d5664-f056-4969-b2cc-c62660f069af:read' # Root Page Information
-  - 'globalsets.8ccd6c1c-8e9b-44e8-93a9-f62589fb4819:read' # Site Information
   - 'globalsets.1a2ba41a-3949-4982-9cb3-f8b03863bcfd:read' # Footer Content
+  - 'globalsets.8ccd6c1c-8e9b-44e8-93a9-f62589fb4819:read' # Site Information
+  - 'globalsets.994d5664-f056-4969-b2cc-c62660f069af:read' # Root Page Information
+  - 'globalsets.b8393df9-fb81-4d70-9ccb-6d030c818580:read' # Gallery Item Defaults
   - 'globalsets.5cf3400b-e67c-4fe1-8f5c-d07510de42a8:read' # Contact Form
   - 'usergroups.everyone:read'
   - 'usergroups.01b89d98-9aa4-46d5-a9a0-60a0c07fd815:read' # Editors
@@ -59,5 +63,3 @@ scope:
   - 'taggroups.c30bad12-1372-49fe-ab6c-a9c33b2860bb:read' # Gallery Item Tags
   - 'taggroups.0d02fdfb-053c-4d46-a5f8-0abf2542a5d2:read' # News Tags
   - 'taggroups.5d162b5e-8723-4b74-a229-f8a52bd30b1c:read' # Staff Tags
-  - 'sites.2c2e1c6a-eb4d-44f1-9a43-8d79b326f354:read' # ES
-  - 'sites.547128fa-4529-4483-9968-66425996b69f:read' # EN

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1680149834
+dateModified: 1683156627
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME
@@ -182,6 +182,7 @@ meta:
     40ee52fe-bbe1-4b44-97ea-ef987105496b: Email # Email
     41a9c595-2a38-40b5-b87c-ada8076913e1: Share # Share
     46d17af4-896a-4fc5-90bf-ac826090d9bc: Credit # Credit
+    46db7366-f372-41c2-9f6a-dc30bcd7a946: 'Callout - News' # Callout - News
     48ba11bd-90a5-4239-a24c-d44d01affbcf: 'Image - quote' # Image - quote
     51d86fa7-e37a-4926-97c8-3112fd6f2fbe: 'Canto DAM' # Canto DAM
     56f60368-4386-4395-92b6-31b15c7663cc: Contact # Contact
@@ -267,6 +268,7 @@ meta:
     960543c0-3ba6-466b-aa9e-9182279dd49a: 'Start Date' # Start Date
     04000104-ec26-4d82-959a-729454e7f1cc: Country # Country
     7187131b-681b-45de-a1ea-87a8d070c05a: 'Gallery Item' # Gallery Item
+    7619020e-9b6f-4526-9359-d6cfb47b33a5: 'Entry - Event' # Entry - Event
     9940892d-32f4-4399-acac-ab559ce1c82b: Common # Common
     30885296-ea6f-4481-8e0f-e9d17e37c7c5: PublisherId # PublisherId
     36247100-a0f8-4eb9-b190-898131bf97b3: Width # Width
@@ -362,6 +364,7 @@ meta:
     e338eebb-6488-4f58-a07e-db43f28ff56b: Image # Image
     e566bfcd-b44b-40b4-9998-5175bcf91df9: 'Related Content' # Related Content
     e24265aa-f05d-42eb-8d44-1ead0005aec1: Link # Link
+    e74470ea-c559-482e-9e3d-2241517a95a7: 'Callout - Event' # Callout - Event
     e425947f-95b4-443c-ab86-fe521acc1f29: 'Gallery Item Type' # Gallery Item Type
     e7913600-c914-4ab1-a9bb-abd2bdcbfb94: 'Custom Name' # Custom Name
     e9726196-f241-49d4-9b6b-9e8d419e6669: 'Link Text' # Link Text


### PR DESCRIPTION
Companion to https://github.com/lsst-epo/rubin-obs-client/pull/302

This change adds 2 new callout Entry types: `calloutNews` and `calloutEvent`.  In each case they provide the content creator fields to select an entry to feature in the callout, and adjust its appearance (color).  The title of the callout (a required field) should automatically update based on the title of the selected entry.