### PR TITLE
[F] isVisible flag for inclusion in header nav

### DIFF
--- a/api/config/project/entryTypes/educatorPages--9d045432-a0fb-4fcd-8bca-3bc93b1f7056.yaml
+++ b/api/config/project/entryTypes/educatorPages--9d045432-a0fb-4fcd-8bca-3bc93b1f7056.yaml
@@ -45,6 +45,18 @@ fieldLayouts:
             width: 25
           -
             elementCondition: null
+            fieldUid: 51322eaa-f9c8-4ade-a6e6-b877bbdc494e # Show Page in the Header Navigation
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 38a760bd-2852-41f6-a1d9-24496b7aeb7b
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: cd801712-4ba3-4a9c-8fab-0d3e2a58b4eb # Description
             instructions: null
             label: null

--- a/api/config/project/entryTypes/investigationLandingPage--b55b0827-5ceb-45e1-bd3c-a35dc4638886.yaml
+++ b/api/config/project/entryTypes/investigationLandingPage--b55b0827-5ceb-45e1-bd3c-a35dc4638886.yaml
@@ -2,6 +2,7 @@ fieldLayouts:
   afc4f64d-d634-46ba-a323-b5a3b1240b03:
     tabs:
       -
+        elementCondition: null
         elements:
           -
             autocapitalize: true
@@ -9,7 +10,9 @@ fieldLayouts:
             autocorrect: true
             class: null
             disabled: false
+            elementCondition: null
             id: null
+            inputType: null
             instructions: null
             label: null
             max: null
@@ -24,85 +27,130 @@ fieldLayouts:
             tip: null
             title: null
             type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: cabb9ba2-26dd-4305-87c9-35e86c08e581
+            userCondition: null
             warning: null
             width: 75
           -
+            elementCondition: null
             fieldUid: 831db889-442e-4553-9076-fc3bc2843c8c # Hide title
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: de2f2f05-a2a6-4ec2-bf7c-b332520cfac3
+            userCondition: null
             warning: null
             width: 25
           -
+            elementCondition: null
+            fieldUid: 51322eaa-f9c8-4ade-a6e6-b877bbdc494e # Show Page in the Header Navigation
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: d0960606-1acb-4991-b542-d782ebf1e8e8
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: cd801712-4ba3-4a9c-8fab-0d3e2a58b4eb # Description
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: b1c500f3-0bf9-42a1-a047-6ce9d64cde13
+            userCondition: null
             warning: null
             width: 100
           -
+            elementCondition: null
             fieldUid: 3c9eb8f7-9f84-4c22-84d5-531be77aa6b6 # Featured Image
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 6e59d689-9240-4e66-bd47-ef253b8dccbd
+            userCondition: null
             warning: null
             width: 100
           -
+            dismissible: false
+            elementCondition: null
             style: tip
             tip: 'This entry type is intended as the starting point for a section describing an Investigation. Child pages will inherit information from the related Investigation and display it in the header.'
             type: craft\fieldlayoutelements\Tip
+            uid: d576bcf6-35ac-456c-a1fc-3403a5151556
+            userCondition: null
           -
+            elementCondition: null
             fieldUid: 72e5075a-9b06-4674-b040-615f4a6f7b70 # Content Blocks - Pages
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: caa935d0-8152-488b-aa96-5b994d910425
+            userCondition: null
             warning: null
             width: 100
         name: Content
-        sortOrder: 1
+        uid: 2ffe92dd-0c18-4233-87d5-4e41b0cc0017
+        userCondition: null
       -
+        elementCondition: null
         elements:
           -
+            elementCondition: null
             fieldUid: b0ce3829-20c1-44ef-a7c7-499800645afc # Header
-            instructions: ''
+            instructions: null
             label: 'Navigation Title'
-            required: ''
+            required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 6478dd37-9407-4821-977b-4e22f7938fea
+            userCondition: null
             warning: null
             width: 100
           -
+            elementCondition: null
             fieldUid: 7db205b7-a548-42f1-8c26-416ec51cf3fa # Text
-            instructions: ''
+            instructions: null
             label: 'Navigation Description'
-            required: ''
+            required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 5afcc4e2-99b8-4f26-a254-3462d6f884d5
+            userCondition: null
             warning: null
             width: 100
           -
+            elementCondition: null
             fieldUid: ecf9a160-a134-43b6-9d4f-8bd547ad101e # Landing Navigation
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 2e00e650-be6e-45b4-8b7e-856a973439f6
+            userCondition: null
             warning: null
             width: 100
         name: Navigation
-        sortOrder: 2
+        uid: caa3dcc6-6ebe-41d1-b3a2-39aeb460ec01
+        userCondition: null
 handle: investigationLandingPage
 hasTitleField: true
 name: 'Investigation Landing Page'
 section: f1b8c943-bc12-4001-9e2a-d531379f1aaf # Pages
+showStatusField: true
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
 sortOrder: 4
 titleFormat: null
 titleTranslationKeyFormat: null

--- a/api/config/project/entryTypes/pages--23eda090-7e8e-401d-ab49-ee4becc34935.yaml
+++ b/api/config/project/entryTypes/pages--23eda090-7e8e-401d-ab49-ee4becc34935.yaml
@@ -45,6 +45,18 @@ fieldLayouts:
             width: 25
           -
             elementCondition: null
+            fieldUid: 51322eaa-f9c8-4ade-a6e6-b877bbdc494e # Show Page in the Header Navigation
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: dca4e7c9-6628-499a-a1cb-f137a09e59db
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: cd801712-4ba3-4a9c-8fab-0d3e2a58b4eb # Description
             instructions: null
             label: null

--- a/api/config/project/entryTypes/redirectPage--15ca4b7f-3874-4461-aae9-869c9cdf076b.yaml
+++ b/api/config/project/entryTypes/redirectPage--15ca4b7f-3874-4461-aae9-869c9cdf076b.yaml
@@ -2,6 +2,7 @@ fieldLayouts:
   2ebb4fd2-b408-4790-a30f-f251e28c995b:
     tabs:
       -
+        elementCondition: null
         elements:
           -
             autocapitalize: true
@@ -9,7 +10,9 @@ fieldLayouts:
             autocorrect: true
             class: null
             disabled: false
+            elementCondition: null
             id: null
+            inputType: null
             instructions: null
             label: null
             max: null
@@ -24,32 +27,56 @@ fieldLayouts:
             tip: null
             title: null
             type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: b28e9611-d044-4958-9001-1343875d2156
+            userCondition: null
             warning: null
             width: 75
           -
+            elementCondition: null
             fieldUid: 831db889-442e-4553-9076-fc3bc2843c8c # Hide title
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 8d683bca-11d9-4804-95e6-b5d1dfbbc2df
+            userCondition: null
             warning: null
             width: 25
           -
+            elementCondition: null
+            fieldUid: 51322eaa-f9c8-4ade-a6e6-b877bbdc494e # Show Page in the Header Navigation
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: f16e2df2-c178-4772-a6ec-b87979d85d40
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: 110434a5-98f0-4679-9f3c-20869a785eee # Link To
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
+            uid: 44eba26d-6129-4256-9776-66aef6bb3f5c
+            userCondition: null
             warning: null
             width: 100
         name: Content
-        sortOrder: 1
+        uid: e18b346b-89cc-4818-a182-8688a2bdadc4
+        userCondition: null
 handle: redirectPage
 hasTitleField: true
 name: 'Redirect Page'
 section: f1b8c943-bc12-4001-9e2a-d531379f1aaf # Pages
+showStatusField: true
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
 sortOrder: 5
 titleFormat: null
 titleTranslationKeyFormat: null

--- a/api/config/project/entryTypes/studentPages--26ca2777-e4c8-41b4-ac93-aa28d09117dd.yaml
+++ b/api/config/project/entryTypes/studentPages--26ca2777-e4c8-41b4-ac93-aa28d09117dd.yaml
@@ -45,6 +45,18 @@ fieldLayouts:
             width: 100
           -
             elementCondition: null
+            fieldUid: 51322eaa-f9c8-4ade-a6e6-b877bbdc494e # Show Page in the Header Navigation
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 2bf94682-cc6b-494b-ad67-719f16425dc4
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: cd801712-4ba3-4a9c-8fab-0d3e2a58b4eb # Description
             instructions: null
             label: null

--- a/api/config/project/fields/isVisible--51322eaa-f9c8-4ade-a6e6-b877bbdc494e.yaml
+++ b/api/config/project/fields/isVisible--51322eaa-f9c8-4ade-a6e6-b877bbdc494e.yaml
@@ -1,0 +1,14 @@
+columnSuffix: xlrruvzj
+contentColumnType: boolean
+fieldGroup: 99f4a28a-48c3-49ca-bb4a-7acbb49fde30 # Pages
+handle: isVisible
+instructions: null
+name: 'Show Page in the Header Navigation'
+searchable: false
+settings:
+  default: true
+  offLabel: Hide
+  onLabel: Show
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Lightswitch

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1711477535
+dateModified: 1712092981
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME
@@ -244,6 +244,7 @@ meta:
     10118ebf-e3bf-4b1b-bbb8-4b57ab3753c8: Caption # Caption
     22728b4f-f1bb-4399-8525-53e3163f0594: 'Slide Block' # Slide Block
     39558c70-8baf-4748-9f12-49e78a04eed5: Job # Job
+    51322eaa-f9c8-4ade-a6e6-b877bbdc494e: 'Show Page in the Header Navigation' # Show Page in the Header Navigation
     51414e74-22c3-4134-9ccb-34f524920c2c: 'Metadata Version' # Metadata Version
     0059967d-f567-4066-a676-02f7c932b843: 'Start Time' # Start Time
     83885be8-333d-42b1-964f-fd89666907ff: 'Embed Title' # Embed Title


### PR DESCRIPTION
Related to https://github.com/lsst-epo/rubin-obs-client/pull/425

Adds an `isVisible` flag to all Page Entry Types to indicate whether or not the page should appear in the Header Navigation.  `isVisible` default value is `true`.