### PR TITLE
[F] dynamic events pages can filter events in CMS

### DIFF
--- a/api/config/project/entryTypes/pages--23eda090-7e8e-401d-ab49-ee4becc34935.yaml
+++ b/api/config/project/entryTypes/pages--23eda090-7e8e-401d-ab49-ee4becc34935.yaml
@@ -172,7 +172,30 @@ fieldLayouts:
             uid: e22ea8f3-dab3-477b-be8f-ab108bbb198c
             userCondition: null
             warning: null
-            width: 100
+            width: 50
+          -
+            elementCondition:
+              class: craft\elements\conditions\entries\EntryCondition
+              conditionRules:
+                -
+                  class: craft\fields\conditions\OptionsFieldConditionRule
+                  fieldUid: fa690eba-6d46-4a5e-9dcd-0845f5b56c1b # Dynamic Component
+                  operator: in
+                  uid: b03dddda-e867-49cb-a5ac-78ba434d3a7d
+                  values:
+                    - events
+              elementType: craft\elements\Entry
+              fieldContext: global
+            fieldUid: 72a74d52-7fcc-4c4e-8db1-1528c7ae5ee3 # Event Type
+            instructions: 'Select event types to show on this page. If empty, all will be shown.'
+            label: 'Show Event Types'
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 14532224-46e4-47a7-9b12-d29b956d5d81
+            userCondition: null
+            warning: null
+            width: 50
         name: Pages
         uid: 66f942b9-81ec-4903-a8e1-e1643e3dd326
         userCondition: null

--- a/api/config/project/fields/eventType--72a74d52-7fcc-4c4e-8db1-1528c7ae5ee3.yaml
+++ b/api/config/project/fields/eventType--72a74d52-7fcc-4c4e-8db1-1528c7ae5ee3.yaml
@@ -2,20 +2,19 @@ columnSuffix: null
 contentColumnType: string
 fieldGroup: bb77d190-487e-45c5-a1d2-0208510a7d88 # Events
 handle: eventType
-instructions: ''
+instructions: null
 name: 'Event Type'
 searchable: false
 settings:
-  allowLimit: false
-  allowMultipleSources: false
   allowSelfRelations: false
-  branchLimit: '1'
-  limit: null
+  branchLimit: null
   localizeRelations: false
+  maintainHierarchy: true
+  maxRelations: null
+  minRelations: null
   selectionLabel: 'Add an event type'
   showSiteMenu: true
   source: 'group:3a3af2ab-b037-455a-ba95-bc3be89efdb0' # Event Filters
-  sources: '*'
   targetSiteId: null
   validateRelatedElements: false
   viewMode: null

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1714683886
+dateModified: 1718918670
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME


### PR DESCRIPTION
CMS changes for adding event filters to event list pages. Allows adding an "Event Type" to an Event List dynamic component page and removes the limit on event categories that can be added. 