### PR TITLE
chore: remove "es" prefix from uri's

### DIFF
--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1721334173
+dateModified: 1723670580
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME

--- a/api/config/project/sections/events--4305f2e2-40b8-47b2-8b62-135b8b57be7f.yaml
+++ b/api/config/project/sections/events--4305f2e2-40b8-47b2-8b62-135b8b57be7f.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/events/{slug}'
+    uriFormat: 'events/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/galleryItems--3a8b9653-cdd3-46ce-84b2-d73b5dc4de63.yaml
+++ b/api/config/project/sections/galleryItems--3a8b9653-cdd3-46ce-84b2-d73b5dc4de63.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/gallery/{slug}'
+    uriFormat: 'gallery/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/glossaryTerms--4ffeb743-f02d-42af-8656-a6f9c1363e79.yaml
+++ b/api/config/project/sections/glossaryTerms--4ffeb743-f02d-42af-8656-a6f9c1363e79.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/for-educators/glossary/{slug}'
+    uriFormat: 'for-educators/glossary/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/homepage--3e10dcca-4dd1-4578-8add-708cd9740881.yaml
+++ b/api/config/project/sections/homepage--3e10dcca-4dd1-4578-8add-708cd9740881.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: es
+    uriFormat: __home__
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/news--11be7603-f576-4af8-93a6-e285e4ff42c4.yaml
+++ b/api/config/project/sections/news--11be7603-f576-4af8-93a6-e285e4ff42c4.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/news/{slug}'
+    uriFormat: 'news/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/pages--f1b8c943-bc12-4001-9e2a-d531379f1aaf.yaml
+++ b/api/config/project/sections/pages--f1b8c943-bc12-4001-9e2a-d531379f1aaf.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: '{parent ? parent.uri : ''es''}/{slug}'
+    uriFormat: '{parent.uri}/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/searchResults--04a48967-eac4-449f-b164-c8ecbb7036d6.yaml
+++ b/api/config/project/sections/searchResults--04a48967-eac4-449f-b164-c8ecbb7036d6.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: es/search
+    uriFormat: search
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/slideshows--fb3283a6-7286-4b2b-a77a-010783dcee7e.yaml
+++ b/api/config/project/sections/slideshows--fb3283a6-7286-4b2b-a77a-010783dcee7e.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/slideshows/{slug}'
+    uriFormat: 'slideshows/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/staffProfiles--78410791-6edc-46c9-a17b-4358dcd545ec.yaml
+++ b/api/config/project/sections/staffProfiles--78410791-6edc-46c9-a17b-4358dcd545ec.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: 'es/explore/staff/{slug}'
+    uriFormat: 'explore/staff/{slug}'
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sections/userProfilePage--1ee32484-2cca-457e-ac23-b3cb13e652d3.yaml
+++ b/api/config/project/sections/userProfilePage--1ee32484-2cca-457e-ac23-b3cb13e652d3.yaml
@@ -20,7 +20,7 @@ siteSettings:
     enabledByDefault: true
     hasUrls: true
     template: null
-    uriFormat: es/user-profile
+    uriFormat: user-profile
   547128fa-4529-4483-9968-66425996b69f: # EN
     enabledByDefault: true
     hasUrls: true

--- a/api/config/project/sites/es--2c2e1c6a-eb4d-44f1-9a43-8d79b326f354.yaml
+++ b/api/config/project/sites/es--2c2e1c6a-eb4d-44f1-9a43-8d79b326f354.yaml
@@ -1,5 +1,5 @@
-baseUrl: '@webBaseUrl'
-enabled: true
+baseUrl: '@webBaseUrl/es'
+enabled: '1'
 handle: es
 hasUrls: true
 language: es


### PR DESCRIPTION
Craft can define a base URL per-site, which is the setup that the investigations uses, so that sections do not need to have URL's defined per-locale but can instead be appended onto the base URL that includes the locale key.