### PR TITLE
feat: linked posts in news articles

### DIFF
--- a/api/config/project/matrixBlockTypes/associatedAsset--f456f3b4-70e5-4692-b114-31a9c47443e9.yaml
+++ b/api/config/project/matrixBlockTypes/associatedAsset--f456f3b4-70e5-4692-b114-31a9c47443e9.yaml
@@ -7,7 +7,7 @@ fieldLayouts:
         elements:
           -
             elementCondition: null
-            fieldUid: 1e0c12ac-5dd7-4ed2-8cda-3801130b11e1 # Gallery Item
+            fieldUid: 1e0c12ac-5dd7-4ed2-8cda-3801130b11e1 # Canto Asset
             instructions: null
             label: null
             required: false
@@ -21,31 +21,23 @@ fieldLayouts:
         uid: 356fb460-95a0-4f65-b622-1acfc19c1d4d
         userCondition: null
 fields:
-  1e0c12ac-5dd7-4ed2-8cda-3801130b11e1: # Gallery Item
-    columnSuffix: null
-    contentColumnType: string
+  1e0c12ac-5dd7-4ed2-8cda-3801130b11e1: # Canto Asset
+    columnSuffix: hnkbhkow
+    contentColumnType:
+      - 'cantoId:string'
+      - 'cantoAlbumId:string'
+      - 'cantoAssetData:json'
+      - 'cantoAlbumData:json'
     fieldGroup: null
-    handle: galleryItem
+    handle: asset
     instructions: 'For a thumbnail and link to full gallery item'
-    name: 'Gallery Item'
+    name: 'Canto Asset'
     searchable: false
     settings:
-      allowSelfRelations: false
-      branchLimit: null
-      localizeRelations: false
-      maintainHierarchy: false
-      maxRelations: 1
-      minRelations: null
-      selectionLabel: 'Select a gallery item'
-      showSiteMenu: false
-      sources:
-        - 'section:3a8b9653-cdd3-46ce-84b2-d73b5dc4de63' # Galleries
-      targetSiteId: null
-      validateRelatedElements: false
-      viewMode: null
+      cantoAssetPickerType: singleImagePicker
     translationKeyFormat: null
-    translationMethod: site
-    type: craft\fields\Entries
-handle: galleryItem
-name: 'Gallery Item'
+    translationMethod: none
+    type: lsst\cantodamassets\fields\CantoDamAsset
+handle: associatedAsset
+name: 'Associated Asset'
 sortOrder: 5

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1738597187
+dateModified: 1738689558
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME
@@ -91,7 +91,7 @@ meta:
     1c0e3777-36ee-449d-948e-01f6fbde3ee6: Sites # Sites
     1c065033-f41d-4566-9863-d34a4bf24836: 'Table Cell' # Table Cell
     1d7324d5-d322-4b06-9eb5-52a6c2f856f3: Location # Location
-    1e0c12ac-5dd7-4ed2-8cda-3801130b11e1: 'Gallery Item' # Gallery Item
+    1e0c12ac-5dd7-4ed2-8cda-3801130b11e1: 'Canto Asset' # Canto Asset
     1ed94e58-7078-46fb-b590-0692fbdf9c20: 'Common Name' # Common Name
     1ed98018-4e61-4580-bee8-961ceab2bb2c: 'Staff Item' # Staff Item
     1ee32484-2cca-457e-ac23-b3cb13e652d3: 'User Profile Page' # User Profile Page
@@ -388,7 +388,7 @@ meta:
     f69fbef5-6f67-486f-9e62-7be537bea803: 'Contact Form Topics' # Contact Form Topics
     f98e0a8a-8a90-4402-9cd5-3cfddd38bff3: Link # Link
     f282d5ff-8da0-4ebb-a160-e5446c02193d: 'Job Position' # Job Position
-    f456f3b4-70e5-4692-b114-31a9c47443e9: 'Gallery Item' # Gallery Item
+    f456f3b4-70e5-4692-b114-31a9c47443e9: 'Associated Asset' # Associated Asset
     f444667c-6ea1-4e0f-89b2-35b059e27bfc: Link # Link
     fa15bb4c-adb8-4393-82c3-15c2b830867c: 'Callout - quote' # Callout - quote
     fa690eba-6d46-4a5e-9dcd-0845f5b56c1b: 'Dynamic Component' # Dynamic Component


### PR DESCRIPTION
Adds a matrix field for news post sidebars for "Associated Asset" which links a selected Canto asset to a gallery if the gallery exists. 

Use with client