### PR TITLE
feat: added weather tooltip and caption fields to SSD content block

### DIFF
--- a/api/config/project/fields/weatherConditionTooltipText--3129863a-64d6-4e56-8de7-53d2b9826b0e.yaml
+++ b/api/config/project/fields/weatherConditionTooltipText--3129863a-64d6-4e56-8de7-53d2b9826b0e.yaml
@@ -1,0 +1,19 @@
+columnSuffix: twbxfjje
+contentColumnType: string(800)
+fieldGroup: 99f4a28a-48c3-49ca-bb4a-7acbb49fde30 # Pages
+handle: weatherConditionTooltipText
+instructions: null
+name: 'Weather Condition Tooltip Text'
+searchable: false
+settings:
+  byteLimit: null
+  charLimit: 200
+  code: false
+  columnType: null
+  initialRows: 4
+  multiline: false
+  placeholder: null
+  uiMode: normal
+translationKeyFormat: null
+translationMethod: site
+type: craft\fields\PlainText

--- a/api/config/project/neoBlockTypes/summitStatusCompactView--d45559e5-fe00-4663-8f09-be0dfc6685ea.yaml
+++ b/api/config/project/neoBlockTypes/summitStatusCompactView--d45559e5-fe00-4663-8f09-be0dfc6685ea.yaml
@@ -11,25 +11,25 @@ fieldLayouts:
         elements:
           -
             elementCondition: null
-            fieldUid: 84c3def8-eed0-4413-9919-181e94e6f7ef # Dome Status
+            fieldUid: aeb0d078-d08a-4ef1-962f-1c58a61a2342 # Weather Condition
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
-            uid: 5fcc78b7-0c31-47d5-a8ab-ebed7c55e6d9
+            uid: 768da371-1d77-45dc-9200-1fa05d477d90
             userCondition: null
             warning: null
             width: 100
           -
             elementCondition: null
-            fieldUid: 32d5861f-010d-4b44-b0f4-56d9392d2c4a # Dome Status Tooltip Text
+            fieldUid: 3129863a-64d6-4e56-8de7-53d2b9826b0e # Weather Condition Tooltip Text
             instructions: null
             label: null
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
-            uid: 9037b1d6-f19a-440a-8566-73a72fb8e04a
+            uid: 0b59e98a-e760-4247-91aa-d5da37d6dfb5
             userCondition: null
             warning: null
             width: 100
@@ -54,6 +54,30 @@ fieldLayouts:
             tip: null
             type: craft\fieldlayoutelements\CustomField
             uid: 2c4b82a2-40b4-408f-8b28-baf40a31977a
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: 84c3def8-eed0-4413-9919-181e94e6f7ef # Dome Status
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 5fcc78b7-0c31-47d5-a8ab-ebed7c55e6d9
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: 32d5861f-010d-4b44-b0f4-56d9392d2c4a # Dome Status Tooltip Text
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 9037b1d6-f19a-440a-8566-73a72fb8e04a
             userCondition: null
             warning: null
             width: 100
@@ -131,13 +155,13 @@ fieldLayouts:
             width: 100
           -
             elementCondition: null
-            fieldUid: aeb0d078-d08a-4ef1-962f-1c58a61a2342 # Weather Condition
+            fieldUid: 7970cd65-7a96-418a-8581-d6df4e039e6d # Plain Text
             instructions: null
-            label: null
+            label: 'Summit Status Dashboard Caption'
             required: false
             tip: null
             type: craft\fieldlayoutelements\CustomField
-            uid: 768da371-1d77-45dc-9200-1fa05d477d90
+            uid: dc6f1e98-85ec-4d69-9887-5bc11bfe234a
             userCondition: null
             warning: null
             width: 100

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1769466608
+dateModified: 1772130506
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME
@@ -290,6 +290,7 @@ meta:
     660361f1-3ecb-4c5e-9274-76e54f1f291f: 'Number of items' # Number of items
     838028d1-bb13-49aa-a2ee-b0b2e7e6a4fa: 'Simple Table' # Simple Table
     960543c0-3ba6-466b-aa9e-9182279dd49a: 'Start Date' # Start Date
+    3129863a-64d6-4e56-8de7-53d2b9826b0e: 'Weather Condition Tooltip Text' # Weather Condition Tooltip Text
     04000104-ec26-4d82-959a-729454e7f1cc: Country # Country
     6637068b-5ee0-4019-a89a-58af8e373b60: Publications # Publications
     7187131b-681b-45de-a1ea-87a8d070c05a: Gallery # Gallery
@@ -312,6 +313,7 @@ meta:
     a8fbf209-7591-40fa-88d4-b5944f4d27d8: 'Landing Page' # Landing Page
     a50ca6cb-f8ed-41c0-9ea1-b3a5c1ed721e: Label # Label
     a50f3dd9-3fa6-4c3d-ad02-39d184c9157a: RA # RA
+    a67f9315-62e4-462e-8002-381aad705d64: 'Rubin Basics' # Rubin Basics
     a71f443d-14a3-402b-90ba-524dcce806d2: 'External URL' # External URL
     a77c49d2-2441-459e-bfea-63e571d25a12: Slideshow # Slideshow
     a130d930-17c1-4bb0-ab02-5b357fbc717c: Image # Image
@@ -360,6 +362,7 @@ meta:
     c41c3f9f-056c-4b0b-8003-2ba5395a615f: Text # Text
     c44a71b5-f4c8-4209-8433-9878aece9aa5: Text # Text
     c832d3ee-de91-4412-87d7-f4a7fd8251eb: Topic # Topic
+    c26595c6-27bb-4c7f-a02a-f05e9e76d116: 'Rubin Basics' # Rubin Basics
     c2617270-9a88-4699-a7e0-6f6975b11e5a: 'Canto DAM' # Canto DAM
     c4060079-e438-4c63-8b06-77cdea857fd9: Text # Text
     cac693b8-f2db-41f9-84e5-a6f16ee8dcbb: 'Flexible Cell Width' # Flexible Cell Width


### PR DESCRIPTION
Resolves #427
Resolves #428 
I also reordered the fields to match how the widgets appear in the frontend.

**Looking for feedback on:**
I chose a plain text field for the lower caption, instead of making a new custom field. I gave it a label for clarity, but let me know if it's preferable to make a custom plain text field.