### PR TITLE
feat: change the Translation Method for the personAffiliation people field to "Translate for each site"

### DIFF
--- a/api/config/project/entryTypes/post--bf90cb02-4359-4659-94a8-0e43cab45695.yaml
+++ b/api/config/project/entryTypes/post--bf90cb02-4359-4659-94a8-0e43cab45695.yaml
@@ -160,7 +160,7 @@ fieldLayouts:
 handle: post
 hasTitleField: true
 name: 'Rubin Basics Post'
-section: a67f9315-62e4-462e-8002-381aad705d64
+section: a67f9315-62e4-462e-8002-381aad705d64 # Rubin Basics
 showStatusField: true
 slugTranslationKeyFormat: null
 slugTranslationMethod: none

--- a/api/config/project/fields/personAffiliation--e6e1a190-5824-49c2-8242-ee637519925d.yaml
+++ b/api/config/project/fields/personAffiliation--e6e1a190-5824-49c2-8242-ee637519925d.yaml
@@ -15,5 +15,5 @@ settings:
   placeholder: null
   uiMode: normal
 translationKeyFormat: null
-translationMethod: none
+translationMethod: site
 type: craft\fields\PlainText

--- a/api/config/project/graphql/schemas/4fe339ec-7579-46f4-a362-df6ee8de4b3c.yaml
+++ b/api/config/project/graphql/schemas/4fe339ec-7579-46f4-a362-df6ee8de4b3c.yaml
@@ -34,7 +34,7 @@ scope:
   - 'entrytypes.5884a9c8-b8b4-48b4-872e-ba06c7fd7bd9:read' # Person
   - 'sections.572f9558-2330-400a-900d-d7f11a4b1e2b:read' # Publications
   - 'entrytypes.046d1ddc-6587-48e3-8cfd-15057c317066:read' # Publication
-  - 'sections.a67f9315-62e4-462e-8002-381aad705d64:read'
+  - 'sections.a67f9315-62e4-462e-8002-381aad705d64:read' # Rubin Basics
   - 'entrytypes.bf90cb02-4359-4659-94a8-0e43cab45695:read' # Rubin Basics Post
   - 'sections.04a48967-eac4-449f-b164-c8ecbb7036d6:read' # Search Results
   - 'entrytypes.229f2975-93d3-4c6a-9996-dfa1de3004ef:read' # Search Results

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1774302828
+dateModified: 1777569565
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME


### PR DESCRIPTION
## What this PR does
Resolves #437 

This PR updates the personAffiliation people field to be translatable by setting it's translation method to "Translate for each site".

## Note to reviewers

I'm not sure why, but this change triggered Craft to add a `# Rubin Basics` comment to two of the files. I left it in as this doesn't change functionality, and it's likely that the next person to make a change will get them added as well.

## Screenshots

### English

<img width="1088" height="581" alt="image" src="https://github.com/user-attachments/assets/bff9c949-73b9-48cf-95ff-f065d21838e3" />

<img width="1337" height="667" alt="image" src="https://github.com/user-attachments/assets/cb467dd4-adc5-4ac5-af61-6891fd2f9484" />

### Spanish

<img width="1082" height="580" alt="image" src="https://github.com/user-attachments/assets/bd193c57-052d-4038-b5c0-aed972e6fc99" />

<img width="1337" height="667" alt="image" src="https://github.com/user-attachments/assets/0ddcb3da-0350-4db7-8cc9-7b70be07b36f" />