### PR TITLE
feat: added Craft fields for Sunrise/Sunset SSD widget

### DIFF
--- a/api/config/project/fields/sunsetSunriseTimes--a6a3f1e3-fa92-4c4e-8142-e69bf5cf1b83.yaml
+++ b/api/config/project/fields/sunsetSunriseTimes--a6a3f1e3-fa92-4c4e-8142-e69bf5cf1b83.yaml
@@ -1,0 +1,14 @@
+columnSuffix: fvomfsgw
+contentColumnType: boolean
+fieldGroup: 99f4a28a-48c3-49ca-bb4a-7acbb49fde30 # Pages
+handle: sunsetSunriseTimes
+instructions: null
+name: 'Sunset Sunrise Times'
+searchable: false
+settings:
+  default: false
+  offLabel: null
+  onLabel: null
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Lightswitch

--- a/api/config/project/fields/sunsetSunriseTimesTooltipText--358515ec-fc1e-48c6-b97f-ab815d992164.yaml
+++ b/api/config/project/fields/sunsetSunriseTimesTooltipText--358515ec-fc1e-48c6-b97f-ab815d992164.yaml
@@ -1,0 +1,19 @@
+columnSuffix: rlauupsj
+contentColumnType: string(800)
+fieldGroup: 99f4a28a-48c3-49ca-bb4a-7acbb49fde30 # Pages
+handle: sunsetSunriseTimesTooltipText
+instructions: null
+name: 'Sunset Sunrise Times Tooltip Text'
+searchable: false
+settings:
+  byteLimit: null
+  charLimit: 200
+  code: false
+  columnType: null
+  initialRows: 4
+  multiline: false
+  placeholder: null
+  uiMode: normal
+translationKeyFormat: null
+translationMethod: site
+type: craft\fields\PlainText

--- a/api/config/project/neoBlockTypes/summitStatusCompactView--d45559e5-fe00-4663-8f09-be0dfc6685ea.yaml
+++ b/api/config/project/neoBlockTypes/summitStatusCompactView--d45559e5-fe00-4663-8f09-be0dfc6685ea.yaml
@@ -155,6 +155,30 @@ fieldLayouts:
             width: 100
           -
             elementCondition: null
+            fieldUid: a6a3f1e3-fa92-4c4e-8142-e69bf5cf1b83 # Sunset Sunrise Times
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 4cc35568-44f9-4c8c-8b2a-e4b37790bcf4
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: 358515ec-fc1e-48c6-b97f-ab815d992164 # Sunset Sunrise Times Tooltip Text
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 7f1b6ad0-553f-4068-9664-e47edc954d55
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: cf32ef76-4cb9-474f-96b6-d7e82d5078e8 # Summit Status Dashboard Caption
             instructions: null
             label: null

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1777569565
+dateModified: 1778690338
 email:
   fromEmail: $EMAIL_FROM_ADDRESS
   fromName: $EMAIL_SENDER_NAME
@@ -284,6 +284,7 @@ meta:
     271253b0-e9b7-4bf1-be32-ce31d71b48b1: Quote # Quote
     272199e3-bb52-4f48-a734-86e150009c76: 'Embed Code' # Embed Code
     312197d8-1241-4fac-8422-febdf44e5e9a: 'Entry - Slideshow' # Entry - Slideshow
+    358515ec-fc1e-48c6-b97f-ab815d992164: 'Sunset Sunrise Times Tooltip Text' # Sunset Sunrise Times Tooltip Text
     418392d0-2ad4-48a1-8eb3-7cdf5437d498: Investigation # Investigation
     547128fa-4529-4483-9968-66425996b69f: EN # EN
     562703bc-5129-4417-b268-c7f1188eb161: Link # Link
@@ -309,6 +310,7 @@ meta:
     a5b8e4fe-87da-48fc-8156-2a2a973b29e5: URL # URL
     a5bb0742-012f-4683-a471-874944bf3280: Image # Image
     a5f6734f-3e3d-4273-9d1f-2ed243b788e4: 'Logo - Large' # Logo - Large
+    a6a3f1e3-fa92-4c4e-8142-e69bf5cf1b83: 'Sunset Sunrise Times' # Sunset Sunrise Times
     a8ba2de3-ff22-4a96-9a53-00b6dec31def: City # City
     a8fbf209-7591-40fa-88d4-b5944f4d27d8: 'Landing Page' # Landing Page
     a50ca6cb-f8ed-41c0-9ea1-b3a5c1ed721e: Label # Label


### PR DESCRIPTION
Resolves #440 

To test, add a `SummitStatusCompactView` block to a page in Craft and confirm you see the new **Sunrise Sunset Times** lightswitch toggle and the **Sunrise Sunset Times Tooltip Text** text field.

<img width="803" height="129" alt="image" src="https://github.com/user-attachments/assets/f49d9869-5d2e-4817-b482-640223cae634" />
